### PR TITLE
add jq to ci-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y && DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs libnode-dev node-gyp npm ruby-dev bundler build-essential zlib1g-dev libpq-dev libmariadbclient-dev tzdata git ghostscript file imagemagick libmagickwand-dev curl libcurl4-gnutls-dev tnef xfonts-base xfonts-75dpi pkg-config autoconf cmake libxslt1-dev libxml2-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y && DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs libnode-dev node-gyp npm ruby-dev bundler build-essential zlib1g-dev libpq-dev libmariadbclient-dev tzdata git ghostscript file imagemagick libmagickwand-dev curl libcurl4-gnutls-dev tnef xfonts-base xfonts-75dpi pkg-config autoconf cmake libxslt1-dev libxml2-dev jq && rm -rf /var/lib/apt/lists/*
 
 # also include bundler 1
 RUN gem install bundler -v '~> 1.0'


### PR DESCRIPTION
jq is required for parsing some data we get as output from json api's